### PR TITLE
fix: accept all org identifiers, even if they're not OVO codes

### DIFF
--- a/lib/organization.js
+++ b/lib/organization.js
@@ -4,7 +4,13 @@ import { RESOURCE_BASE_URI, USERS_GRAPH, AUTH_ORG_CODE_CLAIM, AUTH_ORG_NAME_CLAI
 
 const ovoCodeFromString = function (s) {
   const match = s.match(/OVO\d{6}/);
-  return match ? match[0] : match;
+  // return match ? match[0] : match;
+  // Temporary fix. Non VO organizations don't send us an OVO-code, instead they
+  // send a KBO number. Ideally we want to always have OVO-codes, so we want to
+  // match the incoming KBO-numbers to OVO-codes. Until we do that, we just
+  // accept non OVO-codes as identifiers, because some users really want to log
+  // into Kaleidos.
+  return match ? match[0] : s;
 };
 
 const ensureOrganization = async function (claims) {

--- a/lib/organization.js
+++ b/lib/organization.js
@@ -2,23 +2,10 @@ import { uuid, sparqlEscapeUri, sparqlEscapeString } from 'mu';
 import { querySudo as query, updateSudo as update } from '@lblod/mu-auth-sudo';
 import { RESOURCE_BASE_URI, USERS_GRAPH, AUTH_ORG_CODE_CLAIM, AUTH_ORG_NAME_CLAIM, ACCESS_ALLOWED_STATUS_URI } from '../config';
 
-const ovoCodeFromString = function (s) {
-  const match = s.match(/OVO\d{6}/);
-  // return match ? match[0] : match;
-  // Temporary fix. Non VO organizations don't send us an OVO-code, instead they
-  // send a KBO number. Ideally we want to always have OVO-codes, so we want to
-  // match the incoming KBO-numbers to OVO-codes. Until we do that, we just
-  // accept non OVO-codes as identifiers, because some users really want to log
-  // into Kaleidos.
-  return match ? match[0] : s;
-};
-
 const ensureOrganization = async function (claims) {
   const orgCodeClaim = claims[AUTH_ORG_CODE_CLAIM]; // E.g. "OVO000032"
 
   if (orgCodeClaim) {
-    const ovoCode = ovoCodeFromString(orgCodeClaim);
-
     const queryResult = await query(`
     PREFIX org: <http://www.w3.org/ns/org#>
     PREFIX foaf: <http://xmlns.com/foaf/0.1/>
@@ -30,7 +17,7 @@ const ensureOrganization = async function (claims) {
       GRAPH <${USERS_GRAPH}> {
         ?organization a foaf:Organization ;
             adms:status ?status ;
-            org:identifier ${sparqlEscapeString(ovoCode)} .
+            org:identifier ${sparqlEscapeString(orgCodeClaim)} .
         OPTIONAL { ?organization skos:prefLabel ?name . }
       }
     } LIMIT 1`);
@@ -58,7 +45,6 @@ const insertNewOrganization = async function (claims) {
   const orgUri = `${RESOURCE_BASE_URI}/organisatie/${id}`;
 
   const orgCodeClaim = claims[AUTH_ORG_CODE_CLAIM]; // E.g. "OVO000032"
-  const ovoCode = ovoCodeFromString(orgCodeClaim);
   const orgName = claims[AUTH_ORG_NAME_CLAIM];
 
   const orgNameStatement = orgName ? `${sparqlEscapeUri(orgUri)} skos:prefLabel ${sparqlEscapeString(orgName)} .` : '';
@@ -75,7 +61,7 @@ const insertNewOrganization = async function (claims) {
       ${sparqlEscapeUri(orgUri)} a foaf:Organization ;
          mu:uuid ${sparqlEscapeString(id)} ;
          adms:status ${sparqlEscapeUri(ACCESS_ALLOWED_STATUS_URI)} ;
-         org:identifier ${sparqlEscapeString(ovoCode)} .
+         org:identifier ${sparqlEscapeString(orgCodeClaim)} .
       ${orgNameStatement}
     }
   }`);


### PR DESCRIPTION
This is a temporary workaround to allow users from non-VO organizations to log into Kaleidos. In the long run we want to fetch the OVO-code instead, but this is an easy way to allow our users to log in.