### PR TITLE
Fix/kas 4014 escaped predicates

### DIFF
--- a/lib/organization.js
+++ b/lib/organization.js
@@ -81,7 +81,7 @@ const ensureFreshOrganizationData = async function (organization, claims) {
 
         DELETE WHERE {
           GRAPH <${USERS_GRAPH}> {
-            ${sparqlEscapeUri(organization.uri)} ${sparqlEscapeUri(predicate)} ?value .
+            ${sparqlEscapeUri(organization.uri)} ${predicate} ?value .
         }
       }`);
 
@@ -91,7 +91,7 @@ const ensureFreshOrganizationData = async function (organization, claims) {
 
         INSERT DATA {
           GRAPH <${USERS_GRAPH}> {
-            ${sparqlEscapeUri(organization.uri)} ${sparqlEscapeUri(predicate)} ${sparqlEscapeString(newValue)} .
+            ${sparqlEscapeUri(organization.uri)} ${predicate} ${sparqlEscapeString(newValue)} .
           }
         }`);
       }

--- a/lib/user.js
+++ b/lib/user.js
@@ -89,7 +89,7 @@ const ensureFreshUserData = async function (person, claims) {
 
         DELETE WHERE {
           GRAPH <${USERS_GRAPH}> {
-            ${sparqlEscapeUri(person.uri)} ${sparqlEscapeUri(predicate)} ?value .
+            ${sparqlEscapeUri(person.uri)} ${predicate} ?value .
         }
       }`);
 

--- a/lib/user.js
+++ b/lib/user.js
@@ -99,7 +99,7 @@ const ensureFreshUserData = async function (person, claims) {
 
         INSERT DATA {
           GRAPH <${USERS_GRAPH}> {
-            ${sparqlEscapeUri(person.uri)} ${sparqlEscapeUri(predicate)} ${sparqlEscapeString(newValue)} .
+            ${sparqlEscapeUri(person.uri)} ${predicate} ${sparqlEscapeString(newValue)} .
           }
         }`);
       }


### PR DESCRIPTION
There was only 1 occurrence of an inserted "uri type" predicate on PROD, will correct that manually, so no migrations are needed for this to go through.

