### PR TITLE
KAS-5001: Add endpoint to delete others' sessions

### DIFF
--- a/app.js
+++ b/app.js
@@ -205,7 +205,7 @@ app.get('/sessions/current', async function (req, res, next) {
 
 /**
  * Delete sessions based on a number of parameters
- * The accepted parameters are: 
+ * The accepted parameters are:
  * - ?uuid=<id>: delete all sessions belonging to the user with the given UUID
  * - ?beforeDatetime=ISO-timestamp: delete all sessions before the given timestamp
  * If no parameters are supplied, all sessions will be cleared.
@@ -219,7 +219,7 @@ app.delete('/sessions', async function (req, res, next) {
   }
 
   const date = new Date(beforeDatetime);
-  if (Number.isNaN(date.valueOf())) {
+  if (beforeDatetime && Number.isNaN(date.valueOf())) {
     return next({ message: `beforeDatetime should be a correctly formatted ISO timestamp, you provided: "${beforeDatetime}"`, status: 400 });
   }
 

--- a/lib/session.js
+++ b/lib/session.js
@@ -6,7 +6,10 @@ import { ensureAccountForUser } from './account';
 import { ensureMembership } from './membership';
 import { SESSIONS_GRAPH, USERS_GRAPH, PUBLIC_GRAPH, AUTH_ROLE_CLAIM, parseRoleFromClaim, ACCESS_BLOCKED_STATUS_URI } from '../config';
 import { BlockedError } from './exception';
-import { insertLoginActivity } from './login-activity';
+
+const ROLES = {
+  ADMIN: 'http://themis.vlaanderen.be/id/gebruikersrol/9a969b13-e80b-424f-8a82-a402bcb42bc5',
+}
 
 const removeSession = async function (sessionUri) {
   await update(
@@ -150,10 +153,111 @@ const selectCurrentSession = async function (session) {
   }
 };
 
+const sessionIsAuthorized = async function (sessionUri) {
+  const roleUris = [
+    ROLES.ADMIN,
+  ];
+
+  const queryString = `PREFIX session: <http://mu.semte.ch/vocabularies/session/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX org: <http://www.w3.org/ns/org#>
+
+ASK {
+  VALUES (?roleUri) {
+    ${roleUris.map(uri => `(${sparqlEscapeUri(uri)})`).join(`
+    `)}
+  }
+
+  ${sparqlEscapeUri(sessionUri)} session:account ?account ;
+    ext:sessionMembership / org:role ?roleUri .
+}`;
+  const response = await query(queryString);
+  return response.boolean;
+}
+
+const removeAllSessions = async function () {
+  await update(
+    `PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+     PREFIX session: <http://mu.semte.ch/vocabularies/session/>
+     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+     PREFIX dct: <http://purl.org/dc/terms/>
+
+     DELETE {
+       GRAPH <${SESSIONS_GRAPH}> {
+           ?s ?p ?o .
+       }
+     } WHERE {
+       GRAPH <${SESSIONS_GRAPH}> {
+           ?s ?p ?o .
+           FILTER( STRSTARTS( STR(?s), "http://mu.semte.ch/sessions/" ) )
+       }
+     }`);
+}
+
+const removeAllSessionsByUserId = async function (userId) {
+  await update(
+    `PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+     PREFIX session: <http://mu.semte.ch/vocabularies/session/>
+     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+     PREFIX dct: <http://purl.org/dc/terms/>
+     PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+
+     DELETE {
+       GRAPH <${SESSIONS_GRAPH}> {
+           ?session mu:uuid ?id ;
+                    session:account ?account ;
+                    ext:sessionMembership ?membership ;
+                    dct:modified ?modified .
+       }
+     } WHERE {
+       GRAPH <${USERS_GRAPH}> {
+           ?person a foaf:Person ;
+                   dct:identifier ${sparqlEscapeString(userId)} ;
+                   foaf:account ?account .
+       }
+       GRAPH <${SESSIONS_GRAPH}> {
+           ?session mu:uuid ?id ;
+                    session:account ?account ;
+                    ext:sessionMembership ?membership ;
+                    dct:modified ?modified .
+       }
+     }`);
+};
+
+const removeAllSessionsBeforeDatetime = async function (datetime) {
+  await update(
+    `PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+     PREFIX session: <http://mu.semte.ch/vocabularies/session/>
+     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+     PREFIX dct: <http://purl.org/dc/terms/>
+
+     DELETE {
+       GRAPH <${SESSIONS_GRAPH}> {
+           ?session mu:uuid ?id ;
+                    session:account ?account ;
+                    ext:sessionMembership ?membership ;
+                    dct:modified ?modified .
+       }
+     } WHERE {
+       GRAPH <${SESSIONS_GRAPH}> {
+           ?session mu:uuid ?id ;
+                    session:account ?account ;
+                    ext:sessionMembership ?membership ;
+                    dct:modified ?modified .
+           FILTER( STRSTARTS( STR(?session), "http://mu.semte.ch/sessions/" ) )
+           FILTER( ?modified < ${sparqlEscapeDateTime(datetime)} )
+       }
+     }`);
+};
+
 export {
   removeSession,
   selectUserRole,
   ensureUserResources,
   insertNewSession,
-  selectCurrentSession
+  selectCurrentSession,
+  sessionIsAuthorized,
+  removeAllSessions,
+  removeAllSessionsByUserId,
+  removeAllSessionsBeforeDatetime,
 };


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-5001

Adds an endpoint that can be used by users with the admin role to delete sessions.

As stated in the ticket, this won't actually log out anyone. Logging out requires invalidating the users' cookies, which currently means the user has to refresh the page (which we can't force) or we have to restart the identifier (which we can force).